### PR TITLE
Configure Github-native Dependabot for stylebot and source-reminder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+# Currently each slackbot has it's own directory with dependencies
+# Config Documentation doesn't specify a way to use a list of directories for all npm dependencies
+# If we add a second python or node directory, try adding a second npm/pip package-ecosystem code block
+
+# stylebot directory (node)
+- package-ecosystem: npm
+  directory: "/stylebot"
+  schedule:
+    interval: daily
+    time: "11:00"
+  labels:
+    - "npm"
+    - "dependencies"
+# source-reminder directory (python)
+- package-ecosystem: pip
+  directory: "/source-reminder"
+  schedule:
+    interval: daily
+    time: "11:00"
+  labels:
+    - "python"
+    - "dependencies"


### PR DESCRIPTION
This commit adds the configuration for these two directories.  Didn't add hoedown-helper because we don't have a `requirements.txt` for that app.

Left a comment for future additions to this repo, discussing how to Configure future directories.  One challenge is how to configure dependabot.yml to look in multiple directories for npm dependencies, for example.

See:  [Github Config Options for Dependency Updates - Directory](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#directory)
<img width="913" alt="image" src="https://user-images.githubusercontent.com/5316367/125520937-14a533f4-c35a-48da-acd0-6fdd5ce26f9e.png">


I think a workaround would be to add another code block for each package manager/directory, until Github allows us to give a list value for directories.