### PR TITLE
Build SourceReminder dependencies to local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,32 @@
 node_modules/
 *.zip
 /source-reminder/credentials.json
+.aws-sam
+
+# python packages & directories
+# TODO:  migrate to AWS SAM builds and deploys to keep this tidy
+__pycache__
+_distutils*
+bin
+cachetools*
+certifi*
+charset*
+DateTime*
+google*
+gspread*
+httplib2*
+idna*
+oauth*
+pkg_resources
+pyasn*
+pyparsing*
+pytz*
+requests*
+rsa*
+setuptools*
+six*
+slack*
+urllib3*
+zope*
+distutils*
+

--- a/source-reminder/Makefile
+++ b/source-reminder/Makefile
@@ -7,4 +7,9 @@ deploy: install-deps
 	rm deployment_package.zip
 
 install-deps:
-	pip3 install -r $$(pwd)/requirements.txt
+	pip3 install -t $$(pwd) -r $$(pwd)/requirements.txt
+
+# builds to .aws-sam directory cleaner than "install-deps"
+# todo: switch deploy from manually zipping the directory to using AWS SAM
+sam-build:
+	sam build --use-container


### PR DESCRIPTION
## This PR
- Hotfixes the SourceReminder build so python dependencies are built locally (so they can be uploaded to Lambda in the deploy step)
- Adds `.gitignore` entries for the built/created directories in building the deps

## Next Steps
After running `make` the local directory is messy, this works for now but we should go back to @MatthewTurk247's original path of trying `AWS SAM` CLI, which builds a conveniently packaged `.aws-sam` folder for the build.  I started a Makefile command for the build, next step is to change the `deploy` make command to deploy to use SAM.  Relatedly, this would be a good time/use case for adding a Github Action for automated build and deploys so we aren't running it locally.  To do so would need to change how we package `credentials.json`. 

## Notes
- I already ran `make` with the code in this `Makefile`, so this commit reflects what is deployed on Lambda (the function ran successfully).