### PR TITLE
Fix date bug in source reminder

### DIFF
--- a/source-reminder/lambda_function.py
+++ b/source-reminder/lambda_function.py
@@ -43,7 +43,8 @@ end_formatted = end.strftime(format_template)
 # View the data for the relevant window of time and filter out empty lines.
 records_data = filter(lambda i: not all(value == '' for value in i.values()), records_data)
 timeframe_records = sorted(
-    filter(lambda x: start <= datetime.strptime(x[headers['pub_date']], '%m/%d/%Y') <= end, records_data),
+    filter(lambda x: start - timedelta(days=1) <= datetime.strptime(
+        x[headers['pub_date']], '%m/%d/%Y') <= end + timedelta(days=1), records_data),
     key=lambda i: i[headers['pub_date']])
 sheet_headlines = [k[headers['headline']] for k in timeframe_records]
 SLACK_BOT_TOKEN = os.environ['SLACK_BOT_TOKEN']


### PR DESCRIPTION
- Jolie reported a bug with the source reminder today. She was getting notified about a story she'd already submitted. 
- I could indeed see her entry in the sheet for [this article](https://www.texastribune.org/2021/10/01/texas-migrants-jail-greg-abbott/) published 10/1/2021
- [Looks like](https://github.com/texastribune/tacobots/compare/hotfix-source-reminder?expand=1#diff-afcb43d3428f332167ac0dbd0dbfa59f5a4fac287b70d61ce2ba5dd944dc8dbaL46) when we get all the entries from the sheet, we filter it down to be the last two weeks (not counting the current) so in this case that's 10/1/2021 - 10/15/2021
- The bug was that a story with a pub date like 10/1/2021 was not in range because the filter was actually referencing the start date as 10/01/2021, with a leading zero in the day. Essentially `10/01/2021 <= 10/1/2021 <= 10/15/2021` was false
- This meant when we compared stories published to stories submitted, Jolie's story wasn't found because it wasn't listed in stories submitted.

**Next steps:**
I told Jolie this might have been the reason for the incorrect reminder this week. We'll keep an eye out next week for reports of more incorrect reminders to see if the cause may have been something else.